### PR TITLE
Fix /favicon.ico issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Favioli",
   "description": "Emoji favicons for the web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "background": {
     "scripts": [ "build/background.js" ]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "favioli",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "author": "Ben Pevsner",
   "license": "Unlicense",
   "description": "Emoji Favicons for the web",

--- a/source/utilities/faviconHelpers.js
+++ b/source/utilities/faviconHelpers.js
@@ -31,8 +31,10 @@ export function appendFaviconLink(name) {
   if (existingFavicon) {
     existingFavicon.setAttribute("href", href);
   } else {
-    const link = createLink(href, EMOJI_SIZE);
+    const link = createLink(href, EMOJI_SIZE, "image/png");
+    const defaultLink = createLink("/favicon.ico");
     existingFavicon = documentHead.appendChild(link);
+    documentHead.appendChild(defaultLink);
   }
 }
 
@@ -74,15 +76,20 @@ function createEmojiUrl(emoji) {
 /**
  * Given a url, create a favicon link
  * @param {string} href
- * @param {number} size
+ * @param {number=} size
+ * @param {string=} type
  * @returns {HTMLLinkElement}
  */
-function createLink(href, size) {
+function createLink(href, size, type) {
   const link = document.createElement("link");
   link.rel = "icon";
-  link.type = "image/png";
   link.href = href;
-  link.setAttribute("sizes", `${size}x${size}`);
+  if (type) {
+    link.type = type;
+  }
+  if (size) {
+    link.setAttribute("sizes", `${size}x${size}`);
+  }
   return link;
 }
 


### PR DESCRIPTION
Fix issue where sites that depend on `/favicon.ico` without stating it are mistakenly being replaced with favicons.