### PR TITLE
🐛 Remove unnecessary memoize that is causing 🐛

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -1,5 +1,4 @@
 import debounce from "lodash.debounce";
-import memoize from "lodash.memoize";
 import { DEFAULT_OVERRIDES, DEFAULT_SET } from "./constants/constants";
 import { getSettings, getTab } from "./utilities/chromeHelpers";
 import { EmojiSet } from "./utilities/EmojiSet";
@@ -34,12 +33,12 @@ chrome.runtime.onMessage.addListener(function (message, details) {
  *  @param {object} tab Chrome tab we're visiting
  * .@return {boolean} Whether a website has a native favIcon
  */
-const hasFavIcon = memoize(function (host, tab) {
+const hasFavIcon = function (host, tab) {
   return Boolean(
     tab.favIconUrl &&
     tab.favIconUrl.indexOf("http") > -1
   );
-}, host => host);
+};
 
 
 /**

--- a/source/background.js
+++ b/source/background.js
@@ -29,11 +29,10 @@ chrome.runtime.onMessage.addListener(function (message, details) {
 /**
  *  Determines whether tab has native favIcon.
  *  Once a website is set, it should change favicons
- *  @param {object} host host of the tab
  *  @param {object} tab Chrome tab we're visiting
  * .@return {boolean} Whether a website has a native favIcon
  */
-const hasFavIcon = function (host, tab) {
+const hasFavIcon = function (tab) {
   return Boolean(
     tab.favIconUrl &&
     tab.favIconUrl.indexOf("http") > -1
@@ -88,7 +87,7 @@ function tryToSetFavicon(tabId, tab) {
   const overrideFavIcon = getOverride(settings.overrides, url, settings);
 
   const shouldOverride = Boolean(overrideFavIcon || settings.overrideAll);
-  const shouldSetFavIcon = shouldOverride || !hasFavIcon(url.host, tab);
+  const shouldSetFavIcon = shouldOverride || !hasFavIcon(tab);
 
   if (!shouldSetFavIcon) return;
 

--- a/source/utilities/faviconHelpers.js
+++ b/source/utilities/faviconHelpers.js
@@ -1,4 +1,3 @@
-import debounce from "lodash.debounce";
 import memoize from "lodash.memoize";
 import { EMOJI_SIZE } from "../constants/constants";
 


### PR DESCRIPTION
# Issue
This is what it looks like the problem is:
1. User visits https://inbox.google.com.  Some inbox pages don't have a favicon (because sad)
2. Favioli memoizes that inbox.google.com doesn't have a favicon
3. User visits inbox at https://inbox.google.com/u/0/?pli=1
4. Subsequent link has favicon, but Favioli overrides because memoized that inbox doesn't have one.

# Fix
Remove memoize from  [hasFavIcon](https://github.com/ivebencrazy/favioli/blob/master/source/background.js#L37)
 - Memoize originally was used here for consistency on websites
 - Due to subsequent fixes in favicon discovery, probably no longer necessary?  

Should fix #30 